### PR TITLE
Fix tests associated with new datepicker buttons or bunkers index

### DIFF
--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -22,12 +22,6 @@
     <div id="completed-orders">
       <%= link_to "Completed", admin_dashboard_path(filter: "completed"), id:"completed-filter", class:"btn black location-link" %>
     </div>
-    <div class="item-manager">
-      <h4>Item Manager</h4>
-      <div class="create-item-button center">
-        <%= link_to "Create New Item", new_admin_item_path, class: "btn black site-font" %>
-      </div>
-    </div> <!-- end of item manager -->
   </div>
   <div class="col s9">
     <h4 class="user-orders-header center site-font">Orders</h4>

--- a/test/integration/authenticated_user_test.rb
+++ b/test/integration/authenticated_user_test.rb
@@ -6,11 +6,14 @@ class AuthenticatedUserTest < ActionDispatch::IntegrationTest
   test "guest is prompted to login before checking out" do
     i_need_javascript do
       location = create(:location_with_bunker)
+      bunkers = location.bunkers
+      store = create(:store)
+      store.bunkers << bunkers
       visit bunkers_path
 
       click_on "Book Now!!"
 
-
+      save_and_open_page
       find("#myStartDatePicker").click
       click_on "Select"
 

--- a/test/integration/guest_can_view_listing_test.rb
+++ b/test/integration/guest_can_view_listing_test.rb
@@ -4,7 +4,9 @@ class GuestCanViewListingTest < ActionDispatch::IntegrationTest
   test 'guest can view bunker index' do
     bunkers = create_list(:bunker, 5)
     location = create(:location)
+    store = create(:store)
     location.bunkers << bunkers
+    store.bunkers << bunkers
     visit bunkers_path
 
     assert page.has_content? "Bunkers"
@@ -15,6 +17,8 @@ class GuestCanViewListingTest < ActionDispatch::IntegrationTest
   test 'guest can view individual bunker' do
     bunker = create(:bunker)
     location = create(:location)
+    store = create(:store)
+    store.bunkers << bunker
     location.bunkers << bunker
 
     visit bunkers_path

--- a/test/integration/guest_can_view_locations_test.rb
+++ b/test/integration/guest_can_view_locations_test.rb
@@ -13,6 +13,9 @@ class GuestCanViewLocationsTest < ActionDispatch::IntegrationTest
 
   test 'guest can view bunkers by location' do
     location = create(:location_with_bunker)
+    bunkers = location.bunkers
+    store = create(:store)
+    store.bunkers << bunkers
     visit location_path(location.slug)
 
     assert_equal location_path(location.slug), current_path

--- a/test/integration/user_can_add_bunkers_to_cart_test.rb
+++ b/test/integration/user_can_add_bunkers_to_cart_test.rb
@@ -5,6 +5,8 @@ class UserCanAddBunkersToCart < ActionDispatch::IntegrationTest
   test "displays bunker information plus total cost for all bunkers in cart" do
     location = create(:location_with_bunker)
     bunker = location.bunkers.first
+    store = create(:store)
+    store.bunkers << bunker
 
     visit bunkers_path
 

--- a/test/integration/user_can_checkout_order_test.rb
+++ b/test/integration/user_can_checkout_order_test.rb
@@ -33,7 +33,10 @@ class UserCanCheckoutOrder < ActionDispatch::IntegrationTest
   end
 
   test "unregistered user redirects back to cart after creating an account" do
-    create(:location_with_bunker)
+    location = create(:location_with_bunker)
+    bunkers = location.bunkers
+    store = create(:store)
+    store.bunkers << bunkers
     Role.create(name: "registered_user")
 
     visit bunkers_path

--- a/test/integration/user_can_edit_bunker_nights_booked_in_cart_test.rb
+++ b/test/integration/user_can_edit_bunker_nights_booked_in_cart_test.rb
@@ -3,8 +3,10 @@ require "test_helper"
 class UserCanEditBunkerNightsQuantityInCart < ActionDispatch::IntegrationTest
   test "user can update bunker quantity for cart bunkers" do
     location = create(:location_with_bunker)
+    store = create(:store)
     bunker = location.bunkers.first
-    
+    store.bunkers << bunker
+
     visit bunkers_path
     click_link "Add to Cart"
     visit cart_path

--- a/test/integration/user_can_remove_bunkers_from_cart_test.rb
+++ b/test/integration/user_can_remove_bunkers_from_cart_test.rb
@@ -3,7 +3,9 @@ require "test_helper"
 class UserCanEditBunkerNightsQuantityInCart < ActionDispatch::IntegrationTest
   test "user removes bunker from cart by subtracting until quantity is 0" do
     location = create(:location_with_bunkers)
-    bunker = location.bunkers.first
+    bunkers = location.bunkers
+    store = create(:store)
+    store.bunkers << bunkers
 
     visit bunkers_path
 
@@ -25,6 +27,8 @@ class UserCanEditBunkerNightsQuantityInCart < ActionDispatch::IntegrationTest
   test "user removes bunker from cart by clicking remove button" do
     location = create(:location_with_bunker)
     bunker = location.bunkers.first
+    store = create(:store)
+    store.bunkers << bunker
 
     visit bunkers_path
     click_link "Add to Cart"

--- a/test/integration/user_can_view_bunkers_test.rb
+++ b/test/integration/user_can_view_bunkers_test.rb
@@ -2,10 +2,13 @@ require "test_helper"
 
 class UserCanViewBunkersTest < ActionDispatch::IntegrationTest
   test "displays all bunkers" do
+    store = create(:store)
     location = create(:location)
     bunker_1, bunker_2 = create_list(:bunker, 2)
     location.bunkers << bunker_1
     location.bunkers << bunker_2
+    store.bunkers << bunker_1
+    store.bunkers << bunker_2
 
     visit "/bunkers"
 

--- a/test/models/cart_test.rb
+++ b/test/models/cart_test.rb
@@ -8,8 +8,8 @@ class CartTest < ActiveSupport::TestCase
   test "can add an bunker to cart" do
     cart = Cart.new({ "2" => 1 })
 
-    cart.add_bunker(1)
-    cart.add_bunker(2)
+    cart.add_bunker(1, 1)
+    cart.add_bunker(2, 2)
 
     assert_equal({ "1" => 1, "2" => 2 }, cart.contents)
   end


### PR DESCRIPTION
Fixed tests associated with the datepicker buttons. Some still dont pass since theyre looking
for Add to Cart buttons which no longer exists. These tests still need to be fixed en masse but
that'll happen soon. Also added stores to most of the broken tests because they were
attempting to access bunker index pages which required information from stores which didnt exist.
